### PR TITLE
Automatically add providers if not configured

### DIFF
--- a/src/documentation-providers.js
+++ b/src/documentation-providers.js
@@ -1,0 +1,91 @@
+const sourceCodeProviderPlugin = require('./source-code-provider');
+const typeDocJsonProvider = require('./typedoc-json-provider');
+
+function preload(content, resourcePath) {
+  if (resourcePath.indexOf('app-extras.module.ts') === -1) {
+    return content;
+  }
+
+  let modified = content.toString();
+
+  // Don't modify the module if the user add providers manually.
+  const hasSourceCodeProvider = /SkyDocsSourceCodeProvider/.test(modified);
+  const hasTypeDocJsonProvider = /SkyDocsTypeDefinitionsProvider/.test(modified);
+  if (hasSourceCodeProvider && hasTypeDocJsonProvider) {
+    return content;
+  }
+
+  const imports = [];
+  const providerConfigs = [];
+  let providerOverrides = '';
+
+  if (!hasSourceCodeProvider) {
+    const codeExamplesSourceCode = sourceCodeProviderPlugin.getCodeExamplesSourceCode();
+    imports.push('SkyDocsSourceCodeProvider');
+    providerConfigs.push(`    {
+      provide: SkyDocsSourceCodeProvider,
+      useClass: SkyDocsSourceCodeImplService
+    }`);
+    providerOverrides += `export class SkyDocsSourceCodeImplService {
+  public readonly sourceCode: any[] = ${codeExamplesSourceCode};
+}
+
+`;
+  }
+
+  if (!hasTypeDocJsonProvider) {
+    const documentationConfig = typeDocJsonProvider.getDocumentationConfig();
+    imports.push('SkyDocsTypeDefinitionsProvider');
+    providerConfigs.push(`    {
+      provide: SkyDocsTypeDefinitionsProvider,
+      useClass: SkyDocsTypeDefinitionsImplService
+    }`);
+    providerOverrides += `export class SkyDocsTypeDefinitionsImplService {
+  public readonly anchorIds: {[_: string]: string} = ${JSON.stringify(documentationConfig.anchorIds)};
+  public readonly typeDefinitions: any[] = ${JSON.stringify(documentationConfig.children)};
+}
+
+`;
+  }
+
+  // Modify the `providers` array for AppExtrasModule.
+  const ngModuleMatches = modified.match(/@NgModule\s*\([\s\S]+\)/g);
+  let ngModuleSource = ngModuleMatches[0];
+  const providersMatches = ngModuleSource.match(/(providers\s*:\s*\[[\s\S]*\])/g);
+  let providersSource;
+  if (providersMatches) {
+    providersSource = providersMatches[0];
+  } else {
+    const ngModuleSourceStart = ngModuleSource.substr(0, ngModuleSource.indexOf('{') + 1);
+    const ngModuleSourceEnd = ngModuleSource.substr(ngModuleSourceStart.length);
+    const hasOtherModuleProps = ngModuleSourceEnd.replace(/\s/g, '') !== '})';
+    providersSource = `
+  providers: []${hasOtherModuleProps ? ',' : '\n'}`;
+    ngModuleSource = ngModuleSource.replace(ngModuleSourceStart, ngModuleSourceStart + providersSource);
+  }
+
+  // Apply changes.
+  const providersSourceStart = providersSource.substr(0, providersSource.indexOf('[') + 1);
+  const providersSourceEnd = providersSource.substring(providersSourceStart.length, providersSource.indexOf(']') + 1);
+  ngModuleSource = ngModuleSource.replace(
+    providersSourceStart,
+    providersSourceStart + `
+${providerConfigs.join(',\n')}${providersSourceEnd === ']' ? '\n  ' : ','}`
+  );
+  modified = modified.replace(ngModuleMatches[0], ngModuleSource);
+
+  // Add provider imports and service overrides.
+  modified = `
+import {
+  ${imports.join(',\n  ')}
+} from '@skyux/docs-tools';
+
+${providerOverrides}${modified}
+`;
+
+  return Buffer.from(modified, 'utf8');
+}
+
+module.exports = {
+  preload
+};

--- a/src/documentation-providers.js
+++ b/src/documentation-providers.js
@@ -8,7 +8,7 @@ function preload(content, resourcePath) {
 
   let modified = content.toString();
 
-  // Don't modify the module if the user add providers manually.
+  // Don't modify the module if the user adds providers manually.
   const hasSourceCodeProvider = /SkyDocsSourceCodeProvider/.test(modified);
   const hasTypeDocJsonProvider = /SkyDocsTypeDefinitionsProvider/.test(modified);
   if (hasSourceCodeProvider && hasTypeDocJsonProvider) {
@@ -64,7 +64,7 @@ function preload(content, resourcePath) {
     ngModuleSource = ngModuleSource.replace(ngModuleSourceStart, ngModuleSourceStart + providersSource);
   }
 
-  // Apply changes.
+  // Apply any changes.
   const providersSourceStart = providersSource.substr(0, providersSource.indexOf('[') + 1);
   const providersSourceEnd = providersSource.substring(providersSourceStart.length, providersSource.indexOf(']') + 1);
   ngModuleSource = ngModuleSource.replace(

--- a/src/documentation-providers.spec.js
+++ b/src/documentation-providers.spec.js
@@ -1,0 +1,181 @@
+const mock = require('mock-require');
+const path = require('path');
+
+describe('Documentation providers', () => {
+  let mockFsExtra;
+  let mockGlob;
+
+  const defaultContent = `@NgModule({})
+export class AppExtrasModule { }
+`;
+  const defaultFilePath = path.join('src', 'app', 'app-extras.module.ts');
+
+  beforeEach(() => {
+    mockFsExtra = {
+      ensureFileSync: () => true,
+      pathExistsSync: () => true,
+      readJsonSync: () => ({
+        anchorIds: {},
+        children: []
+      }),
+      readFileSync: () => ''
+    };
+
+    mockGlob = {
+      sync: () => []
+    };
+
+    mock('fs-extra', mockFsExtra);
+    mock('glob', mockGlob);
+  });
+
+  afterEach(() => {
+    mock.stopAll();
+  });
+
+  it('should add imports and providers to AppExtrasModule', () => {
+    const content = Buffer.from(defaultContent, 'utf8');
+    const plugin = mock.reRequire('./documentation-providers');
+    const modified = plugin.preload(content, defaultFilePath).toString();
+
+    expect(modified).toContain(`import {
+  SkyDocsSourceCodeProvider,
+  SkyDocsTypeDefinitionsProvider
+} from '@skyux/docs-tools';`);
+
+    expect(modified).toContain(`export class SkyDocsSourceCodeImplService {
+  public readonly sourceCode: any[] = [];
+}
+
+export class SkyDocsTypeDefinitionsImplService {
+  public readonly anchorIds: {[_: string]: string} = {};
+  public readonly typeDefinitions: any[] = [];
+}`);
+
+    expect(modified).toContain(`providers: [
+    {
+      provide: SkyDocsSourceCodeProvider,
+      useClass: SkyDocsSourceCodeImplService
+    },
+    {
+      provide: SkyDocsTypeDefinitionsProvider,
+      useClass: SkyDocsTypeDefinitionsImplService
+    }
+  ]`);
+
+  });
+
+  it('should not modify any other files', () => {
+    const content = Buffer.from(defaultContent, 'utf8');
+    const plugin = mock.reRequire('./documentation-providers');
+    const modified = plugin.preload(content, 'foobar.ts').toString();
+    expect(modified).toEqual(defaultContent);
+  });
+
+  it('should not modify AppExtrasModule if consumer adds providers manually', () => {
+    const source = `@NgModule({
+  providers: [
+    {
+      provide: SkyDocsSourceCodeProvider,
+      useClass: SkyDocsSourceCodeImplService
+    },
+    {
+      provide: SkyDocsTypeDefinitionsProvider,
+      useClass: SkyDocsTypeDefinitionsImplService
+    }
+  ]
+})
+export class AppExtrasModule { }`;
+
+    const content = Buffer.from(source, 'utf8');
+    const plugin = mock.reRequire('./documentation-providers');
+    const modified = plugin.preload(content, defaultFilePath).toString();
+    expect(modified).toEqual(source);
+  });
+
+  it('should add missing providers if the user adds only a few manually', () => {
+    let source = `@NgModule({
+  providers: [
+    {
+      provide: SkyDocsSourceCodeProvider,
+      useClass: SkyDocsSourceCodeImplService
+    }
+  ]
+})
+export class AppExtrasModule { }`;
+
+    let content = Buffer.from(source, 'utf8');
+    let plugin = mock.reRequire('./documentation-providers');
+    let modified = plugin.preload(content, defaultFilePath).toString();
+    expect(modified).toContain(`{
+      provide: SkyDocsTypeDefinitionsProvider,
+      useClass: SkyDocsTypeDefinitionsImplService
+    }`);
+
+    source = `@NgModule({
+  providers: [
+    {
+      provide: SkyDocsTypeDefinitionsProvider,
+      useClass: SkyDocsTypeDefinitionsImplService
+    }
+  ]
+})
+export class AppExtrasModule { }`;
+
+    content = Buffer.from(source, 'utf8');
+    plugin = mock.reRequire('./documentation-providers');
+    modified = plugin.preload(content, defaultFilePath).toString();
+    expect(modified).toContain(`{
+      provide: SkyDocsSourceCodeProvider,
+      useClass: SkyDocsSourceCodeImplService
+    }`);
+  });
+
+  it('should not override existing providers', () => {
+    const source = `@NgModule({
+  providers: [
+    FooService
+  ]
+})
+export class AppExtrasModule { }`;
+
+    const content = Buffer.from(source, 'utf8');
+    const plugin = mock.reRequire('./documentation-providers');
+    const modified = plugin.preload(content, defaultFilePath).toString();
+    expect(modified).toContain(`providers: [
+    {
+      provide: SkyDocsSourceCodeProvider,
+      useClass: SkyDocsSourceCodeImplService
+    },
+    {
+      provide: SkyDocsTypeDefinitionsProvider,
+      useClass: SkyDocsTypeDefinitionsImplService
+    },
+    FooService
+  ]`);
+  });
+
+  it('should format providers array if other module properties exist', () => {
+    const source = `@NgModule({
+  imports: [],
+  exports: []
+})
+export class AppExtrasModule { }`;
+
+    const content = Buffer.from(source, 'utf8');
+    const plugin = mock.reRequire('./documentation-providers');
+    const modified = plugin.preload(content, defaultFilePath).toString();
+    expect(modified).toContain(`providers: [
+    {
+      provide: SkyDocsSourceCodeProvider,
+      useClass: SkyDocsSourceCodeImplService
+    },
+    {
+      provide: SkyDocsTypeDefinitionsProvider,
+      useClass: SkyDocsTypeDefinitionsImplService
+    }
+  ],
+  imports: [],
+  exports: []`);
+  });
+});

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,10 +1,30 @@
+const logger = require('@blackbaud/skyux-logger');
+
 const documentationGenerator = require('./documentation-generator');
 const documentationProvidersPlugin = require('./documentation-providers');
 const resourcesProviderPlugin = require('./resources-provider');
 const sourceCodeProviderPlugin = require('./source-code-provider');
 const typeDocJsonProviderPlugin = require('./typedoc-json-provider');
+const utils = require('./utils');
 
 function SkyUXPlugin() {
+  const isDevelopment = process.cwd().indexOf('skyux-docs-tools') > -1;
+
+  // Warn the user if `@skyux/docs-tools` is not installed.
+  let doGenerateDocs = false;
+  if (isDevelopment) {
+    doGenerateDocs = true;
+  } else {
+    try {
+      utils.resolveModule('@skyux/docs-tools');
+      doGenerateDocs = true;
+    } catch (e) {
+      logger.warn(
+        '[WARNING] Documentation will not be generated for this library because the required NPM package `@skyux/docs-tools` was not found. ' +
+        'Please install it as a development dependency: `npm i --save-exact --save-dev @skyux/docs-tools`.'
+      );
+    }
+  }
 
   const preload = (content, resourcePath, config) => {
     let modified = content.toString();
@@ -14,9 +34,11 @@ function SkyUXPlugin() {
     switch (config.runtime.command) {
       case 'serve':
       case 'build':
-        modified = sourceCodeProviderPlugin.preload(modified, resourcePath);
-        modified = typeDocJsonProviderPlugin.preload(modified, resourcePath);
-        modified = documentationProvidersPlugin.preload(modified, resourcePath);
+        if (doGenerateDocs) {
+          modified = sourceCodeProviderPlugin.preload(modified, resourcePath);
+          modified = typeDocJsonProviderPlugin.preload(modified, resourcePath);
+          modified = documentationProvidersPlugin.preload(modified, resourcePath);
+        }
         break;
       default:
         break;
@@ -29,7 +51,9 @@ function SkyUXPlugin() {
     switch (command) {
       case 'serve':
       case 'build':
-        documentationGenerator.generateDocumentationFiles();
+        if (doGenerateDocs) {
+          documentationGenerator.generateDocumentationFiles();
+        }
         break;
       default:
         break;

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,4 +1,5 @@
 const documentationGenerator = require('./documentation-generator');
+const documentationProvidersPlugin = require('./documentation-providers');
 const resourcesProviderPlugin = require('./resources-provider');
 const sourceCodeProviderPlugin = require('./source-code-provider');
 const typeDocJsonProviderPlugin = require('./typedoc-json-provider');
@@ -15,6 +16,7 @@ function SkyUXPlugin() {
       case 'build':
         modified = sourceCodeProviderPlugin.preload(modified, resourcePath);
         modified = typeDocJsonProviderPlugin.preload(modified, resourcePath);
+        modified = documentationProvidersPlugin.preload(modified, resourcePath);
         break;
       default:
         break;

--- a/src/plugin.spec.js
+++ b/src/plugin.spec.js
@@ -1,14 +1,20 @@
+const logger = require('@blackbaud/skyux-logger');
 const mock = require('mock-require');
 
 describe('Plugin', function () {
   let mockDocumentationGenerator;
+  let mockDocumentationProviders;
   let mockResourcesProvider;
   let mockSourceCodeProvider;
   let mockTypeDocJsonProvider;
+  let utils;
 
   beforeEach(() => {
     mockDocumentationGenerator = {
       generateDocumentationFiles() {}
+    };
+    mockDocumentationProviders = {
+      preload: (content) => content
     };
     mockResourcesProvider = {
       preload: (content) => content
@@ -21,9 +27,14 @@ describe('Plugin', function () {
     };
 
     mock('./documentation-generator', mockDocumentationGenerator);
+    mock('./documentation-providers', mockDocumentationProviders);
     mock('./resources-provider', mockResourcesProvider);
     mock('./source-code-provider', mockSourceCodeProvider);
     mock('./typedoc-json-provider', mockTypeDocJsonProvider);
+
+    utils = mock.reRequire('./utils');
+
+    spyOn(logger, 'warn');
   });
 
   afterEach(() => {
@@ -42,70 +53,142 @@ describe('Plugin', function () {
     expect(typeof plugin.runCommand).toEqual('function');
   });
 
-  it('should run all Builder plugins', function () {
-    const resourcesProviderSpy = spyOn(mockResourcesProvider, 'preload').and.callThrough();
-    const sourceCodeProviderSpy = spyOn(mockSourceCodeProvider, 'preload').and.callThrough();
-    const typeDocJsonProviderSpy = spyOn(mockTypeDocJsonProvider, 'preload').and.callThrough();
+  describe('Builder plugins', function () {
+    it('should only run the resources plugin by default', function () {
+      const resourcesProviderSpy = spyOn(mockResourcesProvider, 'preload').and.callThrough();
+      const sourceCodeProviderSpy = spyOn(mockSourceCodeProvider, 'preload').and.callThrough();
+      const typeDocJsonProviderSpy = spyOn(mockTypeDocJsonProvider, 'preload').and.callThrough();
+      const documentationProvidersSpy = spyOn(mockDocumentationProviders, 'preload').and.callThrough();
 
-    const obj = mock.reRequire('./plugin');
-    const plugin = new obj.SkyUXPlugin();
+      const obj = mock.reRequire('./plugin');
+      const plugin = new obj.SkyUXPlugin();
 
-    const buffer = Buffer.from('foobar', 'utf8');
-    const resourcePath = '/resource-path';
+      const buffer = Buffer.from('foobar', 'utf8');
+      const resourcePath = '/resource-path';
 
-    plugin.preload(buffer, resourcePath, {
-      runtime: {
-        command: 'serve'
-      }
+      plugin.preload(buffer, resourcePath, {
+        runtime: {
+          command: 'serve'
+        }
+      });
+
+      expect(resourcesProviderSpy).toHaveBeenCalledWith(buffer.toString(), resourcePath);
+      expect(sourceCodeProviderSpy).not.toHaveBeenCalled();
+      expect(typeDocJsonProviderSpy).not.toHaveBeenCalled();
+      expect(documentationProvidersSpy).not.toHaveBeenCalled();
     });
 
-    expect(resourcesProviderSpy).toHaveBeenCalledWith(buffer.toString(), resourcePath);
-    expect(sourceCodeProviderSpy).toHaveBeenCalledWith(buffer.toString(), resourcePath);
-    expect(typeDocJsonProviderSpy).toHaveBeenCalledWith(buffer.toString(), resourcePath);
-  });
+    it('should run documentation plugins if @skyux/docs-tools found', () => {
+      spyOn(utils, 'resolveModule').and.callFake(() => {});
 
-  it('should run all CLI plugins', function () {
-    const documentationGeneratorSpy = spyOn(mockDocumentationGenerator, 'generateDocumentationFiles').and.callThrough();
+      const sourceCodeProviderSpy = spyOn(mockSourceCodeProvider, 'preload').and.callThrough();
+      const typeDocJsonProviderSpy = spyOn(mockTypeDocJsonProvider, 'preload').and.callThrough();
+      const documentationProvidersSpy = spyOn(mockDocumentationProviders, 'preload').and.callThrough();
 
-    const obj = mock.reRequire('./plugin');
-    const plugin = new obj.SkyUXPlugin();
+      const obj = mock.reRequire('./plugin');
+      const plugin = new obj.SkyUXPlugin();
 
-    plugin.runCommand('serve');
+      const buffer = Buffer.from('foobar', 'utf8');
+      const resourcePath = '/resource-path';
 
-    expect(documentationGeneratorSpy).toHaveBeenCalled();
-  });
+      plugin.preload(buffer, resourcePath, {
+        runtime: {
+          command: 'serve'
+        }
+      });
 
-  it('should not run CLI plugin during tests', function () {
-    const documentationGeneratorSpy = spyOn(mockDocumentationGenerator, 'generateDocumentationFiles').and.callThrough();
-
-    const obj = mock.reRequire('./plugin');
-    const plugin = new obj.SkyUXPlugin();
-
-    plugin.runCommand('test');
-    plugin.runCommand('watch');
-
-    expect(documentationGeneratorSpy).not.toHaveBeenCalled();
-  });
-
-  it('should not run all Builder plugins for specific commands', function () {
-    const resourcesProviderSpy = spyOn(mockResourcesProvider, 'preload').and.callThrough();
-    const sourceCodeProviderSpy = spyOn(mockSourceCodeProvider, 'preload').and.callThrough();
-    const typeDocJsonProviderSpy = spyOn(mockTypeDocJsonProvider, 'preload').and.callThrough();
-
-    const obj = mock.reRequire('./plugin');
-    const plugin = new obj.SkyUXPlugin();
-
-    const buffer = Buffer.from('foobar', 'utf8');
-    const resourcePath = '/resource-path';
-
-    plugin.preload(buffer, resourcePath, {
-      runtime: {
-        command: 'build-public-library'
-      }
+      expect(sourceCodeProviderSpy).toHaveBeenCalledWith(buffer.toString(), resourcePath);
+      expect(typeDocJsonProviderSpy).toHaveBeenCalledWith(buffer.toString(), resourcePath);
+      expect(documentationProvidersSpy).toHaveBeenCalledWith(buffer.toString(), resourcePath);
     });
 
-    expect(resourcesProviderSpy).toHaveBeenCalledWith(buffer.toString(), resourcePath);
-    expect(sourceCodeProviderSpy).not.toHaveBeenCalled();
-    expect(typeDocJsonProviderSpy).not.toHaveBeenCalled();
+    it('should run documentation plugins if executed local to skyux-docs-tools repo', () => {
+      spyOn(process, 'cwd').and.returnValue('skyux-docs-tools');
+      spyOn(utils, 'resolveModule').and.callFake(() => {});
+
+      const sourceCodeProviderSpy = spyOn(mockSourceCodeProvider, 'preload').and.callThrough();
+      const typeDocJsonProviderSpy = spyOn(mockTypeDocJsonProvider, 'preload').and.callThrough();
+      const documentationProvidersSpy = spyOn(mockDocumentationProviders, 'preload').and.callThrough();
+
+      const obj = mock.reRequire('./plugin');
+      const plugin = new obj.SkyUXPlugin();
+
+      const buffer = Buffer.from('foobar', 'utf8');
+      const resourcePath = '/resource-path';
+
+      plugin.preload(buffer, resourcePath, {
+        runtime: {
+          command: 'serve'
+        }
+      });
+
+      expect(sourceCodeProviderSpy).toHaveBeenCalledWith(buffer.toString(), resourcePath);
+      expect(typeDocJsonProviderSpy).toHaveBeenCalledWith(buffer.toString(), resourcePath);
+      expect(documentationProvidersSpy).toHaveBeenCalledWith(buffer.toString(), resourcePath);
+    });
+
+    it('should not run certain plugins for specific commands', function () {
+      const resourcesProviderSpy = spyOn(mockResourcesProvider, 'preload').and.callThrough();
+      const sourceCodeProviderSpy = spyOn(mockSourceCodeProvider, 'preload').and.callThrough();
+      const typeDocJsonProviderSpy = spyOn(mockTypeDocJsonProvider, 'preload').and.callThrough();
+      const documentationProvidersSpy = spyOn(mockDocumentationProviders, 'preload').and.callThrough();
+
+      const obj = mock.reRequire('./plugin');
+      const plugin = new obj.SkyUXPlugin();
+
+      const buffer = Buffer.from('foobar', 'utf8');
+      const resourcePath = '/resource-path';
+
+      plugin.preload(buffer, resourcePath, {
+        runtime: {
+          command: 'build-public-library'
+        }
+      });
+
+      expect(resourcesProviderSpy).toHaveBeenCalledWith(buffer.toString(), resourcePath);
+      expect(sourceCodeProviderSpy).not.toHaveBeenCalled();
+      expect(typeDocJsonProviderSpy).not.toHaveBeenCalled();
+      expect(documentationProvidersSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('CLI plugins', function () {
+    it('should run all plugins', function () {
+      spyOn(utils, 'resolveModule').and.callFake(() => {});
+
+      const documentationGeneratorSpy = spyOn(mockDocumentationGenerator, 'generateDocumentationFiles').and.callThrough();
+
+      const obj = mock.reRequire('./plugin');
+      const plugin = new obj.SkyUXPlugin();
+
+      plugin.runCommand('serve');
+
+      expect(documentationGeneratorSpy).toHaveBeenCalled();
+    });
+
+    it('should not run certain plugins during tests', function () {
+      spyOn(utils, 'resolveModule').and.callFake(() => {});
+
+      const documentationGeneratorSpy = spyOn(mockDocumentationGenerator, 'generateDocumentationFiles').and.callThrough();
+
+      const obj = mock.reRequire('./plugin');
+      const plugin = new obj.SkyUXPlugin();
+
+      plugin.runCommand('test');
+      plugin.runCommand('watch');
+
+      expect(documentationGeneratorSpy).not.toHaveBeenCalled();
+    });
+
+    it('should not run certain plugins if @skyux/docs-tools not found', function () {
+      const documentationGeneratorSpy = spyOn(mockDocumentationGenerator, 'generateDocumentationFiles').and.callThrough();
+
+      const obj = mock.reRequire('./plugin');
+      const plugin = new obj.SkyUXPlugin();
+
+      plugin.runCommand('serve');
+
+      expect(documentationGeneratorSpy).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/source-code-provider.js
+++ b/src/source-code-provider.js
@@ -5,11 +5,9 @@ const path = require('path');
 const utils = require('./utils');
 
 /**
- * Writes the raw contents of any project files located in `./src/app/public/plugin-resources/code-examples` to an Angular provider.
- * @param {string} content
+ * Reads the raw contents of any project files located in `./src/app/public/plugin-resources/code-examples`.
  */
-function writeSourceCodeProvider(content) {
-
+function getCodeExamplesSourceCode() {
   const results = glob.sync(
     path.join(
       'src/app/public/plugin-resources/code-examples',
@@ -39,8 +37,11 @@ function writeSourceCodeProvider(content) {
     };
   });
 
-  const formattedSourceCode = JSON.stringify(sourceCode, undefined, 2);
+  return JSON.stringify(sourceCode, undefined, 2);
+}
 
+function writeSourceCodeProvider(content) {
+  const formattedSourceCode = getCodeExamplesSourceCode();
   const className = utils.parseClassName(content);
 
   return `import {
@@ -75,5 +76,6 @@ function preload(content, resourcePath) {
 }
 
 module.exports = {
+  getCodeExamplesSourceCode,
   preload
 };

--- a/src/typedoc-json-provider.js
+++ b/src/typedoc-json-provider.js
@@ -5,19 +5,20 @@ const utils = require('./utils');
 
 const { outputDir } = require('./documentation-generator');
 
+function getDocumentationConfig() {
+  const filePath = path.resolve(`${outputDir}/documentation.json`);
+  return fs.readJsonSync(filePath, {
+    encoding: 'utf8'
+  });
+}
+
 /**
  * Writes the contents of TypeDoc JSON file to an Angular provider.
  * @param {string} content
  */
 function writeTypeDefinitionsProvider(content) {
 
-  const filePath = path.resolve(`${outputDir}/documentation.json`);
-
-  const jsonContent = fs.readJsonSync(
-    filePath,
-    { encoding: 'utf8' }
-  );
-
+  const jsonContent = getDocumentationConfig();
   const className = utils.parseClassName(content);
 
   return `import {
@@ -53,5 +54,6 @@ function preload(content, resourcePath) {
 }
 
 module.exports = {
+  getDocumentationConfig,
   preload
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -27,7 +27,17 @@ function parseClassName(content) {
     .split(' ')[0];
 }
 
+/**
+ * Wrapping require.resolve to make it easier to mock during unit tests.
+ * (It's dangerous to mock the `require` methods.)
+ * See: https://github.com/thlorenz/proxyquire/issues/77#issuecomment-406365452
+ */
+function resolveModule(packageName) {
+  return require.resolve(packageName);
+}
+
 module.exports = {
   isPluginResource,
-  parseClassName
+  parseClassName,
+  resolveModule
 };


### PR DESCRIPTION
If a consumer does not add custom source code or TypeDoc providers, we'll provide them automatically.

You can see it in action, here: https://github.com/blackbaud/skyux-popovers/pull/23/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R54