### PR TITLE
Fix TypeDoc config

### DIFF
--- a/src/documentation-generator.js
+++ b/src/documentation-generator.js
@@ -60,8 +60,7 @@ function generateDocumentationFiles() {
       'node_modules',
       '**/fixtures/**',
       '**/*.spec.ts',
-      '**/plugin-resources/**',
-      '**/code-examples/**'
+      '**/plugin-resources/**'
     ],
     excludeExternals: true,
     excludeNotExported: true,


### PR DESCRIPTION
- Removing `code-examples` from the build is causing problems for `@skyux/docs-tools` because it has a module (and folder named) `code-examples`. 
- The `code-examples` rule in the TypeDoc config isn't needed anyway since the `code-examples` folder lives in the `plugin-resources` folder, which is already removed from the build.