### PR TITLE
Do not warn in preload

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -35,8 +35,6 @@ function SkyUXPlugin() {
           modified = sourceCodeProviderPlugin.preload(modified, resourcePath);
           modified = typeDocJsonProviderPlugin.preload(modified, resourcePath);
           modified = documentationProvidersPlugin.preload(modified, resourcePath);
-        } else {
-          warnMissingPackage();
         }
         break;
       default:


### PR DESCRIPTION
The missing package warning should only be printed during a CLI command, NOT for every file being processed in `preload`.