### PR TITLE
Remove type members that come from extending a type in node_modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2293,9 +2293,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.10.2",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.2.tgz",
-      "integrity": "sha512-GXCYNwqoo0MbLARghYjxVBxDCnU0tLqN7IPLdHHbibCb1NI5zBkU2EPcy/GaVxc0BtTjqyGXJCINe6JMR2Dpow==",
+      "version": "3.10.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.3.tgz",
+      "integrity": "sha512-Lh00i69Uf6G74mvYpHCI9KVVXLcHW/xu79YTvH7Mkc9zyKUeSPz0owW0dguj0Scavns3ZOh3wY63J0Zb97Za2g==",
       "optional": true
     },
     "universalify": {

--- a/src/documentation-generator.js
+++ b/src/documentation-generator.js
@@ -9,37 +9,6 @@ function removeDocumentationFiles() {
   rimraf.sync(outputDir);
 }
 
-function isExternal(type) {
-  if (type.comment && type.comment.tags) {
-    const foundInternalType = type.comment.tags.find((tag) => {
-      return (tag.tagName === 'internal' || tag.tag === 'internal');
-    });
-
-    if (foundInternalType) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-// Remove any type that is marked as `@internal`.
-function removeInternalTypes(project) {
-  project.children = project.children.filter(isExternal);
-  project.children.forEach((type) => {
-    if (type.children) {
-      type.children = type.children.filter((child) => {
-        // Check class methods, too.
-        if (child.signatures) {
-          return isExternal(child.signatures[0]);
-        }
-
-        return isExternal(child);
-      });
-    }
-  });
-}
-
 function parseFriendlyUrlFragment(value) {
   if (!value) {
     return;
@@ -57,6 +26,16 @@ function parseFriendlyUrlFragment(value) {
     .replace(/--/g, '-');
 
   return friendly;
+}
+
+function removeNodeModulesFiles(project) {
+  project.children.forEach((child) => {
+    if (child.children) {
+      child.children = child.children.filter((c) => {
+        return (!/node_modules/.test(c.sources[0].fileName));
+      });
+    }
+  });
 }
 
 function generateDocumentationFiles() {
@@ -82,6 +61,7 @@ function generateDocumentationFiles() {
     logger: 'none',
     mode: 'file',
     module: 'CommonJS',
+    stripInternal: true,
     target: 'ES5'
   });
 
@@ -93,7 +73,7 @@ function generateDocumentationFiles() {
 
   if (project) {
     removeDocumentationFiles();
-    removeInternalTypes(project);
+    removeNodeModulesFiles(project);
 
     const jsonPath = `${outputDir}/documentation.json`;
     app.generateJson(project, jsonPath);

--- a/src/documentation-generator.js
+++ b/src/documentation-generator.js
@@ -28,7 +28,14 @@ function parseFriendlyUrlFragment(value) {
   return friendly;
 }
 
-function removeNodeModulesFiles(project) {
+/**
+ * Some types (read: List Builder) extend third-party types found in `node_modules`.
+ * We should remove them because TypeDoc pulls in all of the third-party's properties into our documentation.
+ * @example ```
+ *   export interface MyState extends Subject {}
+ * ```
+ */
+function removeNodeModulesMembers(project) {
   project.children.forEach((child) => {
     if (child.children) {
       child.children = child.children.filter((c) => {
@@ -73,7 +80,7 @@ function generateDocumentationFiles() {
 
   if (project) {
     removeDocumentationFiles();
-    removeNodeModulesFiles(project);
+    removeNodeModulesMembers(project);
 
     const jsonPath = `${outputDir}/documentation.json`;
     app.generateJson(project, jsonPath);

--- a/src/documentation-generator.spec.js
+++ b/src/documentation-generator.spec.js
@@ -97,62 +97,28 @@ describe('Documentation generator', function () {
     expect(generateSpy).toHaveBeenCalledWith({ children: [] }, path.join(generator.outputDir, 'documentation.json'));
   });
 
-  it('should remove any types or properties marked with `@internal` tag', function () {
+  it('should remove properties that are extended by a type in node_modules', function () {
     mockTypes = [
       {
         name: 'FooType',
         kindString: 'Class',
-        comment: {
-          tags: [
-            {
-              tagName: 'internal'
-            }
-          ]
-        }
-      },
-      {
-        name: 'BarType',
-        kindString: 'Class',
-        comment: {
-          tags: [
-            {
-              tagName: 'example'
-            }
-          ]
-        },
         children: [
           {
-            name: 'internalMethod',
-            signatures: [
+            name: '_fooStream',
+            description: 'This property exists on the type extended by FooType.',
+            sources: [
               {
-                comment: {
-                  tags: [
-                    {
-                      tag: 'internal'
-                    }
-                  ]
-                }
+                fileName: 'node_modules/rxjs/internal/Observable.d.ts'
               }
             ]
-          }
-        ]
-      },
-      {
-        name: 'BazType',
-        kindString: 'Enumeration',
-        comment: {
-          shortText: 'This is the comment.'
-        },
-        children: [
+          },
           {
-            name: 'internalProperty',
-            comment: {
-              tags: [
-                {
-                  tagName: 'internal'
-                }
-              ]
-            }
+            name: 'publicProperty',
+            sources: [
+              {
+                fileName: 'src/app/public/modules/foo/foo-type.ts'
+              }
+            ]
           }
         ]
       }
@@ -166,26 +132,19 @@ describe('Documentation generator', function () {
     expect(generateSpy).toHaveBeenCalledWith({
       children: [
         {
-          name: 'BarType',
+          name: 'FooType',
           kindString: 'Class',
-          comment: {
-            tags: [
-              {
-                tagName: 'example'
-              }
-            ]
-          },
-          children: [],
-          anchorId: 'class-bartype'
-        },
-        {
-          name: 'BazType',
-          kindString: 'Enumeration',
-          comment: {
-            shortText: 'This is the comment.'
-          },
-          anchorId: 'enumeration-baztype',
-          children: []
+          children: [
+            {
+              name: 'publicProperty',
+              sources: [
+                {
+                  fileName: 'src/app/public/modules/foo/foo-type.ts'
+                }
+              ]
+            }
+          ],
+          anchorId: 'class-footype'
         }
       ]
     }, path.join(generator.outputDir, 'documentation.json'));


### PR DESCRIPTION
Some types (read: List Builder) extend types from node_modules. For example:
```
export interface MyState extends Subject {}
```
This isn't ideal because TypeDoc pulls in _all_ of `Subject`'s properties, which we shouldn't be documenting.