### PR TITLE
Use local path for docs-tools during development

### DIFF
--- a/src/documentation-generator.js
+++ b/src/documentation-generator.js
@@ -114,7 +114,7 @@ function generateDocumentationFiles() {
 
     logger.info('Done.');
   } else {
-    logger.warn('TypeDoc project generation failed.');
+    throw new Error('TypeDoc project generation failed. This usually occurs when the underlying TypeScript project does not compile or is invalid. Try running `skyux build` to list any compiler issues.');
   }
 
   process.on('exit', () => {

--- a/src/documentation-generator.spec.js
+++ b/src/documentation-generator.spec.js
@@ -217,14 +217,16 @@ describe('Documentation generator', function () {
     expect(jsonSpy.calls.mostRecent().args[1].anchorIds).toEqual({});
   });
 
-  it('should warn if project generation fails', function () {
+  it('should error if project generation fails', function () {
     spyOn(mockApplication, 'convert').and.returnValue(undefined);
 
-    const loggerSpy = spyOn(mockLogger, 'warn').and.callThrough();
     const generator = mock.reRequire('./documentation-generator');
-    generator.generateDocumentationFiles();
 
-    expect(loggerSpy).toHaveBeenCalledWith('TypeDoc project generation failed.');
+    expect(() => {
+      generator.generateDocumentationFiles();
+    }).toThrowError(
+      'TypeDoc project generation failed. This usually occurs when the underlying TypeScript project does not compile or is invalid. Try running `skyux build` to list any compiler issues.'
+    );
   });
 
   it('should remove temp files when the process exits', () => {

--- a/src/documentation-providers.js
+++ b/src/documentation-providers.js
@@ -74,11 +74,16 @@ ${providerConfigs.join(',\n')}${providersSourceEnd === ']' ? '\n  ' : ','}`
   );
   modified = modified.replace(ngModuleMatches[0], ngModuleSource);
 
+  // Use a local path if executed within `blackbaud/skyux-docs-tools` source code.
+  const importPath = (/(\/|\\)skyux-docs-tools(\/|\\)/.test(resourcePath))
+    ? './public/public_api'
+    : '@skyux/docs-tools';
+
   // Add provider imports and service overrides.
   modified = `
 import {
   ${imports.join(',\n  ')}
-} from '@skyux/docs-tools';
+} from '${importPath}';
 
 ${providerOverrides}${modified}
 `;

--- a/src/documentation-providers.js
+++ b/src/documentation-providers.js
@@ -1,5 +1,6 @@
 const sourceCodeProviderPlugin = require('./source-code-provider');
 const typeDocJsonProvider = require('./typedoc-json-provider');
+const utils = require('./utils');
 
 function preload(content, resourcePath) {
   if (resourcePath.indexOf('app-extras.module.ts') === -1) {
@@ -75,7 +76,7 @@ ${providerConfigs.join(',\n')}${providersSourceEnd === ']' ? '\n  ' : ','}`
   modified = modified.replace(ngModuleMatches[0], ngModuleSource);
 
   // Use a local path if executed within `blackbaud/skyux-docs-tools` source code.
-  const importPath = (/(\/|\\)skyux-docs-tools(\/|\\)/.test(resourcePath))
+  const docsToolsImportPath = utils.isDocsToolsResource(resourcePath)
     ? './public/public_api'
     : '@skyux/docs-tools';
 
@@ -83,7 +84,7 @@ ${providerConfigs.join(',\n')}${providersSourceEnd === ']' ? '\n  ' : ','}`
   modified = `
 import {
   ${imports.join(',\n  ')}
-} from '${importPath}';
+} from '${docsToolsImportPath}';
 
 ${providerOverrides}${modified}
 `;

--- a/src/documentation-providers.spec.js
+++ b/src/documentation-providers.spec.js
@@ -15,10 +15,12 @@ export class AppExtrasModule { }
       ensureFileSync: () => true,
       existsSync: () => true,
       pathExistsSync: () => true,
-      readJsonSync: () => ({
-        anchorIds: {},
-        children: []
-      }),
+      readJsonSync: () => {
+        return {
+          anchorIds: {},
+          children: []
+        };
+      },
       readFileSync: () => ''
     };
 
@@ -178,5 +180,14 @@ export class AppExtrasModule { }`;
   ],
   imports: [],
   exports: []`);
+  });
+
+  it('should use local version of docs-tools if within docs-tools repo', () => {
+    const content = Buffer.from(defaultContent, 'utf8');
+    const resourcePath = path.join('/skyux-docs-tools', defaultFilePath);
+    const plugin = mock.reRequire('./documentation-providers');
+    const modified = plugin.preload(content, resourcePath).toString();
+    expect(modified).not.toContain('@skyux/docs-tools');
+    expect(modified).toContain('\'./public/public_api\'');
   });
 });

--- a/src/source-code-provider.js
+++ b/src/source-code-provider.js
@@ -40,7 +40,7 @@ function getCodeExamplesSourceCode() {
   return JSON.stringify(sourceCode, undefined, 2);
 }
 
-function writeSourceCodeProvider(content) {
+function writeSourceCodeProvider(content, docsToolsImportPath) {
   const formattedSourceCode = getCodeExamplesSourceCode();
   const className = utils.parseClassName(content);
 
@@ -50,7 +50,7 @@ function writeSourceCodeProvider(content) {
 
 import {
   SkyDocsSourceCodeProvider
-} from '@skyux/docs-tools';
+} from '${docsToolsImportPath}';
 
 @Injectable()
 export class ${className} implements SkyDocsSourceCodeProvider {
@@ -70,7 +70,11 @@ function preload(content, resourcePath) {
 
   let modified = content.toString();
 
-  modified = writeSourceCodeProvider(modified);
+  const docsToolsImportPath = utils.isDocsToolsResource(resourcePath)
+    ? './public/public_api'
+    : '@skyux/docs-tools';
+
+  modified = writeSourceCodeProvider(modified, docsToolsImportPath);
 
   return Buffer.from(modified, 'utf8');
 }

--- a/src/source-code-provider.spec.js
+++ b/src/source-code-provider.spec.js
@@ -91,4 +91,13 @@ export class SampleDemoComponent {}
 
     expect(content).toEqual(modified);
   });
+
+  it('should use local version of docs-tools if within docs-tools repo', () => {
+    const content = Buffer.from(defaultContent, 'utf8');
+    const resourcePath = path.join('/skyux-docs-tools', defaultFilePath);
+    const plugin = mock.reRequire('./source-code-provider');
+    const modified = plugin.preload(content, resourcePath).toString();
+    expect(modified).not.toContain('@skyux/docs-tools');
+    expect(modified).toContain('\'./public/public_api\'');
+  });
 });

--- a/src/typedoc-json-provider.js
+++ b/src/typedoc-json-provider.js
@@ -21,7 +21,7 @@ function getDocumentationConfig() {
  * Writes the contents of TypeDoc JSON file to an Angular provider.
  * @param {string} content
  */
-function writeTypeDefinitionsProvider(content) {
+function writeTypeDefinitionsProvider(content, docsToolsImportPath) {
 
   const jsonContent = getDocumentationConfig();
   const className = utils.parseClassName(content);
@@ -32,7 +32,7 @@ function writeTypeDefinitionsProvider(content) {
 
 import {
   SkyDocsTypeDefinitionsProvider
-} from '@skyux/docs-tools';
+} from '${docsToolsImportPath}';
 
 @Injectable()
 export class ${className} implements SkyDocsTypeDefinitionsProvider {
@@ -53,7 +53,13 @@ function preload(content, resourcePath) {
 
   let modified = content.toString();
 
-  modified = writeTypeDefinitionsProvider(modified);
+  // Use a local path if executed within `blackbaud/skyux-docs-tools` source code.
+  const isLocalToDocsToolsRepo = (/(\/|\\)skyux-docs-tools(\/|\\)/.test(resourcePath));
+  const docsToolsImportPath = (isLocalToDocsToolsRepo)
+    ? './public/public_api'
+    : '@skyux/docs-tools';
+
+  modified = writeTypeDefinitionsProvider(modified, docsToolsImportPath);
 
   return Buffer.from(modified, 'utf8');
 }

--- a/src/typedoc-json-provider.js
+++ b/src/typedoc-json-provider.js
@@ -53,8 +53,7 @@ function preload(content, resourcePath) {
 
   let modified = content.toString();
 
-  // Use a local path if executed within `blackbaud/skyux-docs-tools` source code.
-  const docsToolsImportPath = (/(\/|\\)skyux-docs-tools(\/|\\)/.test(resourcePath))
+  const docsToolsImportPath = utils.isDocsToolsResource(resourcePath)
     ? './public/public_api'
     : '@skyux/docs-tools';
 

--- a/src/typedoc-json-provider.js
+++ b/src/typedoc-json-provider.js
@@ -54,8 +54,7 @@ function preload(content, resourcePath) {
   let modified = content.toString();
 
   // Use a local path if executed within `blackbaud/skyux-docs-tools` source code.
-  const isLocalToDocsToolsRepo = (/(\/|\\)skyux-docs-tools(\/|\\)/.test(resourcePath));
-  const docsToolsImportPath = (isLocalToDocsToolsRepo)
+  const docsToolsImportPath = (/(\/|\\)skyux-docs-tools(\/|\\)/.test(resourcePath))
     ? './public/public_api'
     : '@skyux/docs-tools';
 

--- a/src/typedoc-json-provider.spec.js
+++ b/src/typedoc-json-provider.spec.js
@@ -69,4 +69,13 @@ describe('TypeDoc JSON provider', function () {
     expect(content).toEqual(modified);
   });
 
+  it('should use local version of docs-tools if within docs-tools repo', () => {
+    const content = Buffer.from(defaultContent, 'utf8');
+    const resourcePath = path.join('/skyux-docs-tools', defaultFilePath);
+    const plugin = mock.reRequire(PLUGIN_PATH);
+    const modified = plugin.preload(content, resourcePath).toString();
+    expect(modified).not.toContain('@skyux/docs-tools');
+    expect(modified).toContain('\'./public/public_api\'');
+  });
+
 });

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,9 @@
 const path = require('path');
 
+function isDocsToolsResource(resourcePath) {
+  return /(\/|\\)skyux-docs-tools(\/|\\)/.test(resourcePath);
+}
+
 function isPluginResource(resourcePath, fileNameRegex) {
 
   // Resolve the resource path for Windows machines.
@@ -37,6 +41,7 @@ function resolveModule(packageName) {
 }
 
 module.exports = {
+  isDocsToolsResource,
   isPluginResource,
   parseClassName,
   resolveModule


### PR DESCRIPTION
This will allow `skyux serve` to reflect changes to the docs-tools components, when working within the docs-tools repo.

Related: https://github.com/blackbaud/skyux-docs-tools/pull/147